### PR TITLE
Control NaN injection by library (plus some misc. tweaks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ NaN ^  0.0 → 1.0
 
 Most of the time comparison operators are what kill a NaN. But `^` can kill NaNs too.
 
+# Running tests
+
+You can run tests one of two ways:
+
+```
+$ julia --project=. tests/runtests.jl
+```
+
+or via the Julia shell:
+
+```
+julia> ]             # enter the package shell
+pkg> activate .
+(FloatTracker) pkg> test
+```
+
+
 # License
 
 MIT License

--- a/src/Injector.jl
+++ b/src/Injector.jl
@@ -58,7 +58,6 @@ Decision process:
 """
 function should_inject(i::Injector)::Bool
   if i.active && i.ninject > 0 && rand(1:i.odds) == 1
-    println("I am able to inject; checking region...")
     return injectable_region(i, stacktrace())
   end
 
@@ -77,12 +76,11 @@ StackTrace) is a valid point to inject a NaN.
 """
 function injectable_region(i::Injector, raw_frames::StackTraces.StackTrace)::Bool
   # Drop FloatTracker frames
-  frames = collect(Iterators.dropwhile((frame -> frame_library(frame) != "FloatTracker"), raw_frames))
+  frames = collect(Iterators.dropwhile((frame -> frame_library(frame) == "FloatTracker"), raw_frames))
 
   # If neither functions nor libraries are specified, inject as long as we're
   # not inside the standard library.
   if isempty(i.functions) && isempty(i.libraries) && frame_library(frames[1]) !== nothing
-    println("No stipulations; good to inject")
     return true
   end
 
@@ -100,6 +98,9 @@ function injectable_region(i::Injector, raw_frames::StackTraces.StackTrace)::Boo
   # Next check the library set: if we're inside a library that we're interested
   # in, go ahead and inject
   if !isempty(i.libraries)
+    print(frame_library(frames[1]))
+    print(" ← ")
+    println(frames[1].file)
     if frame_library(frames[1]) in i.libraries
       println("Library matches!")
       return true
@@ -107,7 +108,6 @@ function injectable_region(i::Injector, raw_frames::StackTraces.StackTrace)::Boo
   end
 
   # Default: don't inject
-  println("Nothing matches; not injecting")
   return false
 end
 

--- a/src/Injector.jl
+++ b/src/Injector.jl
@@ -90,7 +90,6 @@ function injectable_region(i::Injector, raw_frames::StackTraces.StackTrace)::Boo
     interested_files = map((refs -> refs.file), i.functions)
     in_file_frame_head = Iterators.takewhile((frame -> frame_file(frame) in interested_files), frames)
     if any((frame -> FunctionRef(frame.func, frame_file(frame)) in i.functions), in_file_frame_head)
-      println("Function/file match!")
       return true
     end
   end
@@ -98,11 +97,7 @@ function injectable_region(i::Injector, raw_frames::StackTraces.StackTrace)::Boo
   # Next check the library set: if we're inside a library that we're interested
   # in, go ahead and inject
   if !isempty(i.libraries)
-    print(frame_library(frames[1]))
-    print(" ← ")
-    println(frames[1].file)
     if frame_library(frames[1]) in i.libraries
-      println("Library matches!")
       return true
     end
   end

--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -18,8 +18,8 @@ end
 logger = Logger([])
 
 function set_logger(; filename="default", buffersize=5, print=false, cstg=false, cstgLineNum=true, cstgArgs=true)
-  time = now().instant.periods.value % 99999999
-  log_config.filename = "$(filename)_$(time)"
+  now_str = Dates.format(now(), "yyyymmddHHMMss")
+  log_config.filename = "$(now_str)-$(filename)"
   log_config.buffersize = buffersize
   log_config.printToStdOut = print
   log_config.outputCSTG = cstg

--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -67,7 +67,6 @@ function format_cstg_stackframe(sf::StackTraces.StackFrame)
     return "$(sf)"
   end
   func = String(sf.func)
-  file = split(String(sf.file), ['/', '\\'])[end]
   linfo = "$(sf.linfo)"
   args = if log_config.cstgArgs
     "($(split(linfo, '(')[end])"
@@ -80,7 +79,7 @@ function format_cstg_stackframe(sf::StackTraces.StackFrame)
     ""
   end
 
-  "$(func)$(args) at $(file)$(linenum)"
+  "$(func)$(args) at $(sf.file)$(linenum)"
 end
 
 function write_events(file, events)

--- a/src/TrackedFloat.jl
+++ b/src/TrackedFloat.jl
@@ -1,12 +1,13 @@
 abstract type AbstractTrackedFloat <: AbstractFloat end
 
-injector = Injector(false, 0, 0, [])
+injector = Injector(false, 0, 0, [], [])
 
-function set_inject_nan(should_inject::Bool, odds::Int = 10, n_inject = 1, functions = [])
+function set_inject_nan(should_inject::Bool, odds::Int = 10, n_inject = 1, functions = [], libraries = [])
   injector.active = should_inject
   injector.odds = odds
   injector.ninject = n_inject
   injector.functions = functions
+  injector.libraries = libraries
 end
 
 @inline function check_error(fn, injected::Bool, result, args...)

--- a/test/injector_tests.jl
+++ b/test/injector_tests.jl
@@ -3,12 +3,12 @@ using Test
 include("../src/Injector.jl")
 
 @testset "should_inject basic behavior" begin
-  i1 = Injector(true, 1, 2, [])
+  i1 = Injector(true, 1, 2, [], [])
   @test should_inject(i1)
 
-  i2 = Injector(true, 1, 0, [])
+  i2 = Injector(true, 1, 0, [], [])
   @test ! should_inject(i2)
 
-  i3 = Injector(true, 10^30, 2, []) # No way that this should return true twice in that range
+  i3 = Injector(true, 10^30, 2, [], []) # No way that this should return true twice in that range
   @test !(should_inject(i3) && should_inject(i2))
 end


### PR DESCRIPTION
## Major changes

 - Add option to inject only in certain modules (has issues; see #1)
 - Log files now start with a timestamp to facilitate multiple runs of a test suite

## Discussion

I've updated the FloatTrackerExamples repository for the n-body example. In revision a721f17, I wrote:

> N-body example now only injects NaNs inside of the NBodySimulator and OrdinaryDiffEq libraries—testing showed that NBodySimulator doesn't actually do any work with floating point values; instead it pushes all the work off onto OrdinaryDiffEq.

The N-body example seems to work pretty well and consistently now, which is awesome!

Taylor said that calling `stacktrace()` is an expensive function; I've worked to make sure `stacktrace()` is called as late in the decision process as possible, so as soon as all NaNs to inject have been used up, stuff should speed up.