### PR TITLE
Building out better recording infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,32 @@ NaN ^  0.0 → 1.0
 
 Most of the time comparison operators are what kill a NaN. But `^` can kill NaNs too.
 
+# Recording NaN injections
+
+FloatTracker allows you to fuzz code and inject NaNs wherever a `TrackedFloat` type is used. Moreover, you can record these injections to rerun injections.
+
+**ACHTUNG:** it is critical that inputs to the program be exactly the same for recording and replaying to be consistent. The recordings are sensitive to the number of times a floating point operation is hit.
+
+**TODO:** describe how to set up a recording and replay it.
+
+## Recording sessions
+
+Sometimes we want to inject NaNs throughout the program. We can create a "recording session" that will before each injection check if that point has been tried before. If it has, we move on and try again at the next injection point.
+
+We can tell FloatTracker what we consider to be identical injection points. **TODO:** how *do* we tell FloatTracker what we consider to be the same and not the same? Function boundaries?
+
+## Recording internals
+
+During recording and replaying, we increment a counter each time a floating point operation happens. This doesn't add much overhead [*citation needed*] since we're already intercepting each of the floating point calls anyway—but it explains why we need to make sure our programs are deterministic before recording and replaying.
+
+Injection points are saved to a *recording file*, where each line denotes an injection point. Example:
+
+```
+42, solve.jl, OrdinaryDiffEq::solve OrdinaryDiffEq::do_it Finch::make_it_so
+```
+
+The first field `42` is the injection point, or the nth time a floating point operation was intercepted by FloatTracker. The second field `solve.jl` acts as a little sanity check: this is the first non-FloatTracker file off of the stack trace. After that comes a list of module names paired with the function on the call stack.
+
 # Generating CSTGs
 
 Get the [CSTG](https://github.com/utahplt/cstg) code.

--- a/src/TrackedFloat.jl
+++ b/src/TrackedFloat.jl
@@ -1,7 +1,9 @@
 abstract type AbstractTrackedFloat <: AbstractFloat end
 
+# This variable is visible module-wide
 injector = make_injector(should_inject=false, odds=0, n_inject=0)
 
+# Old, dumpy API
 function set_inject_nan(i::Injector)
   injector.active = i.active
   injector.odds = i.odds

--- a/test/logger_perf_tests.jl
+++ b/test/logger_perf_tests.jl
@@ -1,0 +1,58 @@
+# Run this by entering the Julia REPL and running
+   # include("test/logger_perf_tests.jl")
+
+using FloatTracker: TrackedFloat64, write_out_logs, set_exclude_stacktrace, set_logger
+using FileIO, Profile, FlameGraphs, Plots, ProfileView
+
+function track(loops)
+  acc = []
+
+  for i in 1:loops
+    foo = TrackedFloat64(10.0)
+    bar = TrackedFloat64(5.0)
+    baz = bar - (i % 6)
+    push!(acc, (foo - (i % 18)) * (bar / baz) + (bar / baz))
+  end
+
+  return acc
+end
+
+function no_track(loops)
+  acc = []
+
+  for i in 1:loops
+    foo = 10.0
+    bar = 5.0
+    baz = bar - (i % 6)
+    push!(acc, (foo - (i % 18)) * (bar / baz) + (bar / baz))
+  end
+
+  return acc
+end
+
+loops = 50_000
+
+set_logger(filename="log_perf", buffersize=10_000)
+set_exclude_stacktrace([:prop,:kill])
+
+no_track(1)
+track(1)
+
+println("No tracking:")
+Profile.clear();
+@profview no_track(loops)
+# notrack_g = flamegraph(C=true)
+
+println("Halting for input")
+readline()
+
+# FlameGraphs.save("notrack_perf.jlprof", Profile.retrieve()...)
+# Profile.clear();
+
+println("Tracking:")
+@profview track(loops)
+# track_g = flamegraph(C=true)
+# FlameGraphs.save("track_perf.jlprof", Profile.retrieve()...)
+
+println("Halting for input")
+readline()

--- a/test/recording_session_tests.jl
+++ b/test/recording_session_tests.jl
@@ -1,0 +1,18 @@
+using Test
+
+@testset "recording captures detailed information" begin
+end
+
+@testset "recording session basics" begin
+  # Make sure that correct number of runs happen
+end
+
+@testset "recording session coverage" begin
+  # Ensure test will move on over previously recorded points
+end
+
+@testset "injection point equivalence" begin
+  # Ensure that module equivalence works; i.e. if we say that stack frames are
+  # equivalent modulo a particular file+line combo in a module, then we should
+  # treat different calls to that point as being the same.
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Test
 
-println("injector tests")
-
+println("--- injector tests ---")
 include("injector_tests.jl")
+
+println("--- recording session tests ---")
+include("recording_session_tests.jl")


### PR DESCRIPTION
This PR makes it possible to set up "recording sessions", where you can get FloatTracker to fuzz a wider space in the program by remembering where previous injections happened and trying alternates.

Before this gets merged, there are a few items that need to be handled:

 - [ ] Writing out module/function pairs on the end of recording lines needs to be implemented
 - [ ] Parsing the list of module/functions from a recording file needs to be implemented
 - [ ] New tests for capture sessions

That's not an exhaustive checklist of every task needed to finish this PR, but those are some that need to be done before this thing merges.