### PR TITLE
Refactor FloatTracker configuration API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ Massive configuration API rewrite. This should make it easier to maintain and ex
 
 ### Replaced functions
 
- - `set_logger(kwargs...)` → `set_logger_config!(kwargs...)`
+ - `set_logger(kwargs...)` → `config_logger!(kwargs...)`
 
    Continues to accept the same keyword arguments as the original function.
 
- - `set_inject_nan(args...)` → `set_injector_config!(kwargs...)`
+ - `set_inject_nan(args...)` → `config_injector!(kwargs...)`
 
    Instead of positional arguments, the injector function now takes keyword arguments. New keyword arguments and their defaults:
    
@@ -37,7 +37,7 @@ Massive configuration API rewrite. This should make it easier to maintain and ex
 
  - `set_exclude_stacktrace([:prop...])` → `set_exclude_stacktrace!([:prop...])`
 
-   Convenience function; you can also set the exclusions by using a keyword argument to `set_logger_config!`.
+   Convenience function; you can also set the exclusions by using a keyword argument to `config_logger!`.
 
 ## 0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## 2023-05-30
+
+Massive configuration API rewrite. This should make it easier to maintain and extend in the future.
+
+### New functions
+
+ - `enable_nan_injection!(n_inject = 1)`
+ - `disable_nan_injection!()`
+ - `enable_injection_recording!(recording_file::String = "ft_recording")`
+ - `set_injection_replay!(replay_file::String)`
+
+### Replaced functions
+
+ - `set_logger(kwargs...)` → `set_logger_config!(kwargs...)`
+
+   Continues to accept the same keyword arguments as the original function.
+
+ - `set_inject_nan(args...)` → `set_injector_config!(kwargs...)`
+
+   Instead of positional arguments, the injector function now takes keyword arguments. New keyword arguments and their defaults:
+   
+    + `should_inject::Bool=true`
+    + `odds::Int64=10`
+    + `n_inject::Int64=1`
+    + `functions=[]`
+    + `libraries=[]`
+    + `replay=""`
+    + `record=""`
+
+   See also the new convenience functions that break out some of the roles of this function into smaller, semantic chunks.
+
+ - `set_exclude_stacktrace([:prop...])` → `set_exclude_stacktrace!([:prop...])`
+
+   Convenience function; you can also set the exclusions by using a keyword argument to `set_logger_config!`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2023-05-30
+We strive to follow [SemVer](https://semver.org/) conventions. Per [item 4 in the spec](https://semver.org/#semantic-versioning-specification-semver), until the API stabilizes and we make an official `1.0.0` release, expect new features and/or breaking changes with every update to the minor version number. Patch numbers will continue to be backwards-compatible with a given minor version number.
+
+That said, this is research software, so expect some instability as we aim first and foremost to push the boundaries of what is possible.
+
+## 0.1.0
 
 Massive configuration API rewrite. This should make it easier to maintain and extend in the future.
 
@@ -34,3 +38,7 @@ Massive configuration API rewrite. This should make it easier to maintain and ex
  - `set_exclude_stacktrace([:prop...])` → `set_exclude_stacktrace!([:prop...])`
 
    Convenience function; you can also set the exclusions by using a keyword argument to `set_logger_config!`.
+
+## 0.0.0
+
+Beginning of change tracking.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Options:
 
  - `active::Boolean` inject only if true
 
- - `ninject::Int` maximum number of NaNs to inject; gets decremented every time
+ - `n_inject::Int` maximum number of NaNs to inject; gets decremented every time
    a NaN gets injected
 
  - `odds::Int` inject a NaN with 1:odds probability—higher value → rarer to

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ These events are then stored in a buffered log and can be written out to a file 
 
 ## Usage
 
-Wrap as many of your inputs in `TrackedFloatN` as you can, and FloatTracker should take care of the rest.
+ 1. Import/use and call `ft_init()` to initialize the logger and injector config to their default values.
+ 2. Add additional customization to logging and injection.
+ 3. Wrap as many of your inputs in `TrackedFloatN` as you can
 
-That said, there are two things you should configure when using FloatTracker:
+FloatTracker should take care of the rest!
+
+Digging into step 2, there are two things that you can customize after initialization:
 
  - **The logger**
 
@@ -98,8 +102,9 @@ injection points is a union of the places matched by `functions` and `libraries`
 ## Example
 
 ```julia
-using FloatTracker: TrackedFloat16, write_out_logs, set_logger_config!
+using FloatTracker: TrackedFloat16, write_out_logs, set_logger_config!, ft_init()
 
+ft_init()
 set_logger_config!(filename="max")
 
 function maximum(lst)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Options:
 
  - `printToStdOut::Bool` Whether or not to write logs to STDOUT; defaults  to `false`.
 
- - `outputCSTG::Bool` Write logs in CSTG format.
+ - `cstg::Bool` Write logs in CSTG format.
 
  - `cstgLineNum::Bool` Include the line number in CSTG output.
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,20 @@ Digging into step 2, there are two things that you can customize after initializ
 ### Configuring the logger
 
 ```julia
-set_logger_config!(filename="whatever")        # set log file basename to "whatever"; files match "$timestamp-whatever_*.txt"
-set_exclude_stacktrace!([:prop,:gen,:kill])    # disable all event logging
+# Set log file basename to "whatever"; all log files have the timestamp prepended
+set_logger_config!(filename="whatever")
+
+# There are three kinds of events that we log:
+#  - `:gen`  → when a NaN gets created from non-NaN arguments
+#  - `:prop` → when a NaN argument leads to a NaN result
+#  - `:kill` → when a NaN argument does *not* lead to a NaN result
+#
+# If logs are too noisy, we can disable some or all of the logs. For example,
+# here we disable everything but NaN generation logging:
+set_exclude_stacktrace!([:prop,:kill])
 ```
 
-Options:
+Keyword arguments for `set_logger_config!`:
 
  - `filename::String` Basename of the file to write logs to.
 
@@ -89,7 +98,7 @@ enable_injection_recording!("ft_recording") # this is just the file basename; wi
 set_injection_replay!("20230530T145830-ft_recording.txt")
 ```
 
-Options:
+Keyword arguments for `set_injector_config!`:
 
  - `active::Boolean` inject only if true
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These events are then stored in a buffered log and can be written out to a file 
 
 ## Usage
 
- 1. Call `using FloatTracker`; you may want to include functions like `enable_nan_injection!` or `set_logger_config!` or the like. (See below for more details.)
+ 1. Call `using FloatTracker`; you may want to include functions like `enable_nan_injection!` or `config_logger!` or the like. (See below for more details.)
  2. Add additional customization to logging and injection.
  3. Wrap as many of your inputs in `TrackedFloatN` as you can
 
@@ -47,7 +47,7 @@ Digging into step 2, there are two things that you can customize after initializ
 
 ```julia
 # Set log file basename to "whatever"; all log files have the timestamp prepended
-set_logger_config!(filename="whatever")
+config_logger!(filename="whatever")
 
 # There are three kinds of events that we log:
 #  - `:gen`  → when a NaN gets created from non-NaN arguments
@@ -59,7 +59,7 @@ set_logger_config!(filename="whatever")
 set_exclude_stacktrace!([:prop,:kill])
 ```
 
-Keyword arguments for `set_logger_config!`:
+Keyword arguments for `config_logger!`:
 
  - `filename::String` Basename of the file to write logs to.
 
@@ -98,7 +98,7 @@ enable_injection_recording!("ft_recording") # this is just the file basename; wi
 set_injection_replay!("20230530T145830-ft_recording.txt")
 ```
 
-Keyword arguments for `set_injector_config!`:
+Keyword arguments for `config_injector!`:
 
  - `active::Boolean` inject only if true
 
@@ -125,9 +125,9 @@ injection points is a union of the places matched by `functions` and `libraries`
 ## Example
 
 ```julia
-using FloatTracker: TrackedFloat16, write_out_logs, set_logger_config!, ft_init()
+using FloatTracker: TrackedFloat16, write_out_logs, config_logger!, ft_init()
 
-set_logger_config!(filename="max")
+config_logger!(filename="max")
 
 function maximum(lst)
   max_seen = 0.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These events are then stored in a buffered log and can be written out to a file 
 
 ## Usage
 
- 1. Import/use and call `ft_init()` to initialize the logger and injector config to their default values.
+ 1. Call `using FloatTracker`; you may want to include functions like `enable_nan_injection!` or `set_logger_config!` or the like. (See below for more details.)
  2. Add additional customization to logging and injection.
  3. Wrap as many of your inputs in `TrackedFloatN` as you can
 
@@ -75,6 +75,20 @@ Options:
 
 ### Configuring the injector
 
+```julia
+# Inject 2 NaNs
+enable_nan_injection!(2)
+
+# Inject 2 NaNs, except when in the function "nope" in "way.jl"
+enable_nan_injection!(n_inject=2, functions=[FunctionRef("nope", "way.jl")])
+
+# Enable recording of injections
+enable_injection_recording!("ft_recording") # this is just the file basename; will have timestamp prepended
+
+# Enable recording playback
+set_injection_replay!("20230530T145830-ft_recording.txt")
+```
+
 Options:
 
  - `active::Boolean` inject only if true
@@ -104,7 +118,6 @@ injection points is a union of the places matched by `functions` and `libraries`
 ```julia
 using FloatTracker: TrackedFloat16, write_out_logs, set_logger_config!, ft_init()
 
-ft_init()
 set_logger_config!(filename="max")
 
 function maximum(lst)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,59 @@ That said, there are two things you should configure when using FloatTracker:
 
 ### Configuring the logger
 
+```julia
+set_logger_config!(filename="whatever")        # set log file basename to "whatever"; files match "$timestamp-whatever_*.txt"
+set_exclude_stacktrace!([:prop,:gen,:kill])    # disable all event logging
+```
+
+Options:
+
+ - `filename::String` Basename of the file to write logs to.
+
+   Constructors automatically prefix the timestamp to the beginning of this
+   basename so the logs are grouped together chronologically.
+
+ - `buffersize::Int` Number of logs to buffer in memory before writing to file.
+
+   Defaults to 1000. Decrease if you are crashing without getting the logs that you need.
+
+ - `printToStdOut::Bool` Whether or not to write logs to STDOUT; defaults  to `false`.
+
+ - `outputCSTG::Bool` Write logs in CSTG format.
+
+ - `cstgLineNum::Bool` Include the line number in CSTG output.
+
+ - `cstgArgs::Bool` Include arguments to functions in CSTG output.
+
+ - `maxLogs::Union{Int,Unbounded}` Maximum number of events to log; defaults to `Unbounded`.
+
+ - `exclusions::Array{Symbol}` Events to not log; defaults to `[:prop]`.
+
 ### Configuring the injector
+
+Options:
+
+ - `active::Boolean` inject only if true
+
+ - `ninject::Int` maximum number of NaNs to inject; gets decremented every time
+   a NaN gets injected
+
+ - `odds::Int` inject a NaN with 1:odds probability—higher value → rarer to
+   inject
+
+ - `functions::Array{FunctionRef}` if given, only inject NaNs when within these
+   functions; default is to not discriminate on functions
+
+ - `libraries::Array{String}` if given, only inject NaNs when within this library.
+
+ - `record::String` if given, record injection invents in a way that can be
+   replayed later with the `replay` argument.
+
+ - `replay::String` if given, ignore all previous directives and use this file
+   for injection replay.
+
+`functions` and `libraries` work together as a union: i.e. the set of possible NaN
+injection points is a union of the places matched by `functions` and `libraries`.
 
 ## Example
 

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -180,7 +180,7 @@ ft_config = nothing
 """
     ft_init()
 
-Initialize the global FloatTracker configuration.
+Initialize the global FloatTracker configuration. (Automatically called when using function by `__init__`)
 
 We need to make this a function, otherwise it can cache the value of the
 timestamp used for writing unique log files.

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -55,8 +55,6 @@ mutable struct LoggerConfig
   maxLogs::Union{Int,Unbounded}
   exclusions::Array{Symbol}
 end
-LoggerConfig() =
-  LoggerConfig("ft_log", 1000)
 LoggerConfig(filename) =
   LoggerConfig(filename, 1000)
 LoggerConfig(filename, buff_size) =
@@ -64,7 +62,7 @@ LoggerConfig(filename, buff_size) =
 LoggerConfig(filename, buff_size, cstg) =
   LoggerConfig(filename=filename, buffersize=buff_size, print=false, cstg=cstg, cstgLineNum=true, cstgArgs=true)
 
-function LoggerConfig(; filename="default", buffersize=1000, print=false, cstg=false, cstgLineNum=true, cstgArgs=true,
+function LoggerConfig(; filename="ft_log", buffersize=1000, print=false, cstg=false, cstgLineNum=true, cstgArgs=true,
                       max_logs=Unbounded(), exclusions=[:prop])
   now_str = Dates.format(now(), "yyyymmddHHMMss")
   LoggerConfig("$now_str-$filename", buffersize, print, cstg, cstgLineNum, cstgArgs, max_logs, exclusions)
@@ -176,9 +174,49 @@ end
 
 ft_config = FtConfig(LoggerConfig(), InjectorConfig(), SessionConfig())
 
-set_logger_config!(log::LoggerConfig)     = ft_config.log = log
+"""
+    set_logger_config!(log::LoggerConfig)
+    set_logger_config!(; args...)
+
+Set the logger for the global FloatTracker configuration instance.
+
+Takes either a `LoggerConfig` struct, or the same keyword arguments as the
+`LoggerConfig` constructor.
+
+**NOTE** the second version overwrites the *entire* instance of `LoggerConfig`
+in the global config instance; i.e. you should not use this to update just the
+filename for the logger, because it will also overwrite the CSTG config, etc.
+"""
+set_logger_config!(log::LoggerConfig) = ft_config.log = log
+set_logger_config!(; args...) = ft_config.log = LoggerConfig(; args...)
+
+"""
+    set_injector_config!(log::InjectorConfig)
+    set_injector_config!(; args...)
+
+Set the injector for the global FloatTracker configuration instance.
+
+Takes either a `InjectorConfig` struct, or the same keyword arguments as the
+`InjectorConfig` constructor.
+
+Same caveats apply to this function as to `set_logger_config!`.
+"""
 set_injector_config!(inj::InjectorConfig) = ft_config.inj = inj
-set_session_config!(ses::SessionConfig)   = ft_config.ses = ses
+set_injector_config!(; args...) = ft_config.inj = InjectorConfig(; args...)
+
+"""
+    set_session_config!(log::SessionConfig)
+    set_session_config!(; args...)
+
+Set the session for the global FloatTracker configuration instance.
+
+Takes either a `SessionConfig` struct, or the same keyword arguments as the
+`SessionConfig` constructor.
+
+Same caveats apply to this function as to `set_logger_config!`.
+"""
+set_session_config!(ses::SessionConfig) = ft_config.ses = ses
+set_session_config!(; args...) = ft_config.ses = SessionConfig(; args...)
 
 """
     set_exclude_stacktrace!(exclusions = [:prop])

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -35,7 +35,7 @@ Struct containing all configuration for the logger.
 
  - `printToStdOut::Bool` Whether or not to write logs to STDOUT; defaults  to `false`.
 
- - `outputCSTG::Bool` Write logs in CSTG format.
+ - `cstg::Bool` Write logs in CSTG format.
 
  - `cstgLineNum::Bool` Include the line number in CSTG output.
 
@@ -49,7 +49,7 @@ mutable struct LoggerConfig
   filename::String
   buffersize::Int
   printToStdOut::Bool
-  outputCSTG::Bool
+  cstg::Bool
   cstgLineNum::Bool
   cstgArgs::Bool
   maxLogs::Union{Int,Unbounded}
@@ -271,7 +271,7 @@ Turn on NaN injection. Optionally configure the odds for injection, as well as
 the number of NaNs to inject, and the functions/libraries in which to inject
 NaNs. Overrides unspecified arguments to their defaults.
 """
-function enable_nan_injection!(n_inject::Int = 1)
+function enable_nan_injection!(n_inject::Int)
   ft_config.inj.active    = true
   ft_config.inj.ninject   = n_inject
 end

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -253,6 +253,9 @@ Globally set the types of stack traces to not collect.
 
 See documentation for the `event()` function for details on the types of events
 that can be put into this list.
+
+Convenience function; You can also set the stack trace exclusions with
+a keyword argument to `set_logger_config!`.
 """
 set_exclude_stacktrace!(exclusions = [:prop]) = ft_config.log.exclusions = exclusions
 
@@ -268,10 +271,11 @@ Turn on NaN injection. Optionally configure the odds for injection, as well as
 the number of NaNs to inject, and the functions/libraries in which to inject
 NaNs. Overrides unspecified arguments to their defaults.
 """
-function enable_nan_injection!(n_inject::Int)
+function enable_nan_injection!(n_inject::Int = 1)
   ft_config.inj.active    = true
   ft_config.inj.ninject   = n_inject
 end
+
 function enable_nan_injection!(; odds::Int = 10, n_inject::Int = 1, functions::Array{FunctionRef} = [], libraries::Array{String} = [])
   ft_config.inj.active    = true
   ft_config.inj.odds      = odds
@@ -291,10 +295,19 @@ consider using the one-argument form of `enable_nan_injection!(n_inject::Int)`.
 disable_nan_injection!() = ft_config.inj.active = false
 
 """
-    enable_injection_recording!(; recording_file::String="ft_recording")
+    enable_injection_recording!(recording_file::String="ft_recording")
 
 Turn on recording.
 """
-enable_injection_recording!(; recording_file::String="ft_recording") = ft_config.inj.record = recording_file
+enable_injection_recording!(recording_file::String="ft_recording") = ft_config.inj.record = recording_file
 
-set_injection_replay!(; replay_file::String) = ft_config.inj = InjectorConfig(replay=replay_file)
+"""
+    set_injection_replay!(replay_file::String)
+
+Sets the injector to read from a replay file.
+
+Note that this overwrites all previous configuration to the injector file, as
+once you are replaying an injection recording, all other configuration ceases to
+matter.
+"""
+set_injection_replay!(replay_file::String) = ft_config.inj = InjectorConfig(replay=replay_file)

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -93,7 +93,7 @@ Struct describing parameters for injecting NaNs
 
  - `active::Boolean` inject only if true
 
- - `ninject::Int` maximum number of NaNs to inject; gets decremented every time
+ - `n_inject::Int` maximum number of NaNs to inject; gets decremented every time
    a NaN gets injected
 
  - `odds::Int` inject a NaN with 1:odds probability—higher value → rarer to
@@ -117,7 +117,7 @@ injection points is a union of the places matched by `functions` and `libraries`
 mutable struct InjectorConfig
   active::Bool
   odds::Int64
-  ninject::Int64
+  n_inject::Int64
   functions::Array{FunctionRef}
   libraries::Array{String}
   replay::String
@@ -273,13 +273,13 @@ NaNs. Overrides unspecified arguments to their defaults.
 """
 function enable_nan_injection!(n_inject::Int)
   ft_config.inj.active    = true
-  ft_config.inj.ninject   = n_inject
+  ft_config.inj.n_inject   = n_inject
 end
 
 function enable_nan_injection!(; odds::Int = 10, n_inject::Int = 1, functions::Array{FunctionRef} = [], libraries::Array{String} = [])
   ft_config.inj.active    = true
   ft_config.inj.odds      = odds
-  ft_config.inj.ninject   = n_inject
+  ft_config.inj.n_inject   = n_inject
   ft_config.inj.functions = functions
   ft_config.inj.libraries = libraries
 end

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -176,9 +176,9 @@ end
 
 ft_config = FtConfig(LoggerConfig(), InjectorConfig(), SessionConfig())
 
-set_global_logger!(log::LoggerConfig)     = ft_config.log = log
-set_global_injector!(inj::InjectorConfig) = ft_config.inj = inj
-set_global_session!(ses::SessionConfig)   = ft_config.ses = ses
+set_logger_config!(log::LoggerConfig)     = ft_config.log = log
+set_injector_config!(inj::InjectorConfig) = ft_config.inj = inj
+set_session_config!(ses::SessionConfig)   = ft_config.ses = ses
 
 """
     set_exclude_stacktrace!(exclusions = [:prop])
@@ -189,3 +189,46 @@ See documentation for the `event()` function for details on the types of events
 that can be put into this list.
 """
 set_exclude_stacktrace!(exclusions = [:prop]) = ft_config.log.exclusions = exclusions
+
+"""
+    enable_nan_injection!(n_inject::Int)
+
+Turn on NaN injection and injection `n_inject` NaNs. Does not modify odds,
+function and library lists, or recording/replay state.
+
+    enable_nan_injection!(; odds::Int = 10, n_inject::Int = 1, functions::Array{FunctionRef} = [], libraries::Array{String} = [])
+
+Turn on NaN injection. Optionally configure the odds for injection, as well as
+the number of NaNs to inject, and the functions/libraries in which to inject
+NaNs. Overrides unspecified arguments to their defaults.
+"""
+function enable_nan_injection!(n_inject::Int)
+  ft_config.inj.active    = true
+  ft_config.inj.ninject   = n_inject
+end
+function enable_nan_injection!(; odds::Int = 10, n_inject::Int = 1, functions::Array{FunctionRef} = [], libraries::Array{String} = [])
+  ft_config.inj.active    = true
+  ft_config.inj.odds      = odds
+  ft_config.inj.ninject   = n_inject
+  ft_config.inj.functions = functions
+  ft_config.inj.libraries = libraries
+end
+
+"""
+    disable_nan_injection!()
+
+Turn off NaN injection.
+
+If you want to re-enable NaN injection after calling `disable_nan_injection!`,
+consider using the one-argument form of `enable_nan_injection!(n_inject::Int)`.
+"""
+disable_nan_injection!() = ft_config.inj.active = false
+
+"""
+    enable_injection_recording!(; recording_file::String="ft_recording")
+
+Turn on recording.
+"""
+enable_injection_recording!(; recording_file::String="ft_recording") = ft_config.inj.record = recording_file
+
+set_injection_replay!(; replay_file::String) = ft_config.inj = InjectorConfig(replay=replay_file)

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -201,8 +201,8 @@ ft__get_global_ft_config_for_test() = ft_config
 export ft__get_global_ft_config_for_test
 
 """
-    set_logger_config!(log::LoggerConfig)
-    set_logger_config!(; args...)
+    config_logger!(log::LoggerConfig)
+    config_logger!(; args...)
 
 Set the logger for the global FloatTracker configuration instance.
 
@@ -213,12 +213,12 @@ In the case where only a few arguments are specified, it will override only
 those fields, i.e. the entire LoggerConfig won't be replaced. This is useful,
 for example, if you need to adjust a field in the middle of a test.
 """
-set_logger_config!(log::LoggerConfig) = ft_config.log = log
-set_logger_config!(; args...) = patch_config!(ft_config.log; args...)
+config_logger!(log::LoggerConfig) = ft_config.log = log
+config_logger!(; args...) = patch_config!(ft_config.log; args...)
 
 """
-    set_injector_config!(log::InjectorConfig)
-    set_injector_config!(; args...)
+    config_injector!(log::InjectorConfig)
+    config_injector!(; args...)
 
 Set the injector for the global FloatTracker configuration instance.
 
@@ -226,14 +226,14 @@ Takes either a `InjectorConfig` struct, or the same keyword arguments as the
 `InjectorConfig` constructor.
 
 Passing a partial list of keyword arguments has the same behavior as it does
-with `set_logger_config!`.
+with `config_logger!`.
 """
-set_injector_config!(inj::InjectorConfig) = ft_config.inj = inj
-set_injector_config!(; args...) = patch_config!(ft_config.inj; args...)
+config_injector!(inj::InjectorConfig) = ft_config.inj = inj
+config_injector!(; args...) = patch_config!(ft_config.inj; args...)
 
 """
-    set_session_config!(log::SessionConfig)
-    set_session_config!(; args...)
+    config_session!(log::SessionConfig)
+    config_session!(; args...)
 
 Set the session for the global FloatTracker configuration instance.
 
@@ -241,10 +241,10 @@ Takes either a `SessionConfig` struct, or the same keyword arguments as the
 `SessionConfig` constructor.
 
 Passing a partial list of keyword arguments has the same behavior as it does
-with `set_logger_config!`.
+with `config_logger!`.
 """
-set_session_config!(ses::SessionConfig) = ft_config.ses = ses
-set_session_config!(; args...) = patch_config!(ft_config.ses; args...)
+config_session!(ses::SessionConfig) = ft_config.ses = ses
+config_session!(; args...) = patch_config!(ft_config.ses; args...)
 
 """
     set_exclude_stacktrace!(exclusions = [:prop])
@@ -255,7 +255,7 @@ See documentation for the `event()` function for details on the types of events
 that can be put into this list.
 
 Convenience function; You can also set the stack trace exclusions with
-a keyword argument to `set_logger_config!`.
+a keyword argument to `config_logger!`.
 """
 set_exclude_stacktrace!(exclusions = [:prop]) = ft_config.log.exclusions = exclusions
 

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -65,7 +65,7 @@ LoggerConfig(filename, buff_size, cstg) =
   LoggerConfig(filename=filename, buffersize=buff_size, print=false, cstg=cstg, cstgLineNum=true, cstgArgs=true)
 
 function LoggerConfig(; filename="default", buffersize=1000, print=false, cstg=false, cstgLineNum=true, cstgArgs=true,
-                      max_logs=Unbounded, exclusions=[:prop])
+                      max_logs=Unbounded(), exclusions=[:prop])
   now_str = Dates.format(now(), "yyyymmddHHMMss")
   LoggerConfig("$now_str-$filename", buffersize, print, cstg, cstgLineNum, cstgArgs, max_logs, exclusions)
 end
@@ -142,7 +142,7 @@ function InjectorConfig(; should_inject::Bool=true, odds::Int64=10, n_inject::In
     else
       []
     end
-  return InjectorConfig(should_inject, odds, n_inject, functions, libraries, replay, record, "", 0, script, 1)
+  return InjectorConfig(should_inject, odds, n_inject, functions, libraries, replay, record, "", 0, InjectorScript(script), 1)
 end
 
 #
@@ -155,7 +155,7 @@ mutable struct SessionConfig
   maxKills::Union{Int,Unbounded}
   maxEvents::Union{Int,Unbounded}
 end
-SessionConfig() = SessionConfig(Unbounded, Unbounded, Unbounded, Unbounded)
+SessionConfig() = SessionConfig(Unbounded(), Unbounded(), Unbounded(), Unbounded())
 
 """
 FloatTracker config struct

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -1,0 +1,106 @@
+#
+# Unified config for FloatTracker
+#
+
+# Singleton to represent unrestricted max{Logs,Gens,Props,Kills,Events}
+struct Unbounded
+end
+
+# Error logging configuration
+struct LoggerConfig
+  filename::String
+  buffersize::Int
+  printToStdOut::Bool
+  outputCSTG::Bool
+  cstgLineNum::Bool
+  cstgArgs::Bool
+  maxLogs::Union{Int,Unbounded}
+end
+
+struct InjectorScript
+  script::Array{ReplayPoint}
+end
+InjectorScript() = InjectorScript([])
+InjectorScript(script_name::String) = InjectorScript(parse_replay_file(script_name))
+
+function parse_replay_file(replay::String)::Array{ReplayPoint}
+  return [parse_replay_line(l) for l in readlines(replay)]
+end
+
+function parse_replay_line(line::String)::ReplayPoint
+  m = match(r"^(\d+), ([^,]*), (.*)$", line)
+  return ReplayPoint(parse(Int64, m.captures[1]), Symbol(m.captures[2]), split(m.captures[3]))
+end
+
+"""
+Struct describing parameters for injecting NaNs
+
+## Fields
+
+ - `active::Boolean` inject only if true
+
+ - `ninject::Int` maximum number of NaNs to inject; gets decremented every time
+   a NaN gets injected
+
+ - `odds::Int` inject a NaN with 1:odds probability—higher value → rarer to
+   inject
+
+ - `functions::Array{FunctionRef}` if given, only inject NaNs when within these
+   functions; default is to not discriminate on functions
+
+ - `libraries::Array{String}` if given, only inject NaNs when within this library.
+
+ - `record::String` if given, record injection invents in a way that can be
+   replayed later with the `replay` argument.
+
+ - `replay::String` if given, ignore all previous directives and use this file
+   for injection replay.
+
+`functions` and `libraries` work together as a union: i.e. the set of possible NaN
+injection points is a union of the places matched by `functions` and `libraries`.
+
+"""
+struct InjectorConfig
+  active::Bool
+  odds::Int64
+  ninject::Int64
+  functions::Array{FunctionRef}
+  libraries::Array{String}
+  replay::String
+  record::String
+  session::String
+
+  # private fields
+  place_counter::Int64
+  replay_script::InjectorScript
+  replay_head::Int64
+end
+
+# Recording session configuration
+struct SessionConfig
+  maxGens::Union{Int,Unbounded}
+  maxProps::Union{Int,Unbounded}
+  maxKills::Union{Int,Unbounded}
+  maxEvents::Union{Int,Unbounded}
+end
+
+"""
+FloatTracker config struct
+
+## Logger Config
+## Injector Config
+## Session Config
+"""
+mutable struct FtConfig
+  log::LoggerConfig
+  inj::InjectorConfig
+  ses::SessionConfig
+end
+
+# Global config instance
+
+ft_config = FtConfig()
+
+set_global_logger!(log::LoggerConfig)     = ft_config.log = log
+set_global_injector!(inj::InjectorConfig) = ft_config.inj = inj
+set_global_session!(ses::SessionConfig)   = ft_config.ses = ses

--- a/src/Event.jl
+++ b/src/Event.jl
@@ -3,40 +3,6 @@
 end
 
 """
-    Event
-
-Struct representing some event in the life of a NaN.
-
-`evt_type` options:
-
- - `:injected`
- - `:gen`
- - `:prop`
- - `:kill`
-"""
-struct Event
-  evt_type::Symbol
-  op::String
-  args::Array{Any}
-  result::Any
-  trace::StackTraces.StackTrace
-end
-
-exclude_stacktrace = [:prop]
-
-"""
-    set_exclude_stacktrace(exclusions = [:prop])
-
-Set the types of stack traces to not collect.
-
-See documentation for the `event()` function for details on the types of events
-that can be put into this list.
-"""
-function set_exclude_stacktrace(exclusions = [:prop])
-  global exclude_stacktrace = exclusions
-end
-
-"""
     event(op, args, result, is_injected = false)
 
 Construct an `Event` struct.
@@ -61,7 +27,7 @@ function event(op, args, result, is_injected = false) :: Event
       :kill
     end
 
-  st = if evt_type in exclude_stacktrace
+  st = if evt_type in ft_config.log.exclusions
     Base.StackFrame[]
   else
     stacktrace()[2:end]

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -1,6 +1,6 @@
 module FloatTracker
 
-export FtConfig, TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef
+export FtConfig, ft_init, TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef
 export LoggerConfig, set_logger_config!, set_exclude_stacktrace!, print_log, write_out_logs
 export InjectorConfig, set_injector_config!, enable_nan_injection!, disable_nan_injection!, enable_injection_recording!, set_injection_replay!
 export SessionConfig

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -1,8 +1,8 @@
 module FloatTracker
 
 export FtConfig, ft_init, TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef
-export LoggerConfig, set_logger_config!, set_exclude_stacktrace!, print_log, write_out_logs
-export InjectorConfig, set_injector_config!, enable_nan_injection!, disable_nan_injection!, enable_injection_recording!, set_injection_replay!
+export LoggerConfig, config_logger!, set_exclude_stacktrace!, print_log, write_out_logs
+export InjectorConfig, config_injector!, enable_nan_injection!, disable_nan_injection!, enable_injection_recording!, set_injection_replay!
 export SessionConfig
 
 include("SharedStructs.jl")     # Structures used in multiple places throughout FloatTracker

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -1,6 +1,6 @@
 module FloatTracker
 
-export TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef
+export FtConfig, TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef
 export LoggerConfig, set_logger_config!, set_exclude_stacktrace!, print_log, write_out_logs
 export InjectorConfig, set_injector_config!, enable_nan_injection!, disable_nan_injection!, enable_injection_recording!, set_injection_replay!
 export SessionConfig

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -12,4 +12,6 @@ include("Logger.jl")            # Formatting and writing of error/event logs
 include("Injector.jl")          # NaN-injection logic
 include("TrackedFloat.jl")      # Principle datatype; overrides of all Base.* functions
 
+__init__() = ft_init()
+
 end

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -1,14 +1,15 @@
 module FloatTracker
 
+export TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef
+export LoggerConfig, set_logger_config!, set_exclude_stacktrace!, print_log, write_out_logs
+export InjectorConfig, set_injector_config!, enable_nan_injection!, enable_injection_recording!
+export SessionConfig
+
 include("SharedStructs.jl")
 include("Config.jl")
-
-export TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef, print_log, write_out_logs, set_inject_nan, set_exclude_stacktrace, set_logger, make_injector
-import Base
-
 include("Event.jl")
 include("Logger.jl")
 include("Injector.jl")
 include("TrackedFloat.jl")
 
-end # module
+end

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -2,14 +2,14 @@ module FloatTracker
 
 export TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef
 export LoggerConfig, set_logger_config!, set_exclude_stacktrace!, print_log, write_out_logs
-export InjectorConfig, set_injector_config!, enable_nan_injection!, enable_injection_recording!
+export InjectorConfig, set_injector_config!, enable_nan_injection!, disable_nan_injection!, enable_injection_recording!, set_injection_replay!
 export SessionConfig
 
-include("SharedStructs.jl")
-include("Config.jl")
-include("Event.jl")
-include("Logger.jl")
-include("Injector.jl")
-include("TrackedFloat.jl")
+include("SharedStructs.jl")     # Structures used in multiple places throughout FloatTracker
+include("Config.jl")            # Primary interface routines: routines to control injection, logging, etc.
+include("Event.jl")             # Routines for diagnosing exceptional events
+include("Logger.jl")            # Formatting and writing of error/event logs
+include("Injector.jl")          # NaN-injection logic
+include("TrackedFloat.jl")      # Principle datatype; overrides of all Base.* functions
 
 end

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -1,5 +1,8 @@
 module FloatTracker
 
+include("SharedStructs.jl")
+include("Config.jl")
+
 export TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef, print_log, write_out_logs, set_inject_nan, set_exclude_stacktrace, set_logger, make_injector
 import Base
 

--- a/src/Injector.jl
+++ b/src/Injector.jl
@@ -45,6 +45,8 @@ function should_inject(i::InjectorConfig)::Bool
   return false
 end
 
+export should_inject            # only for testing
+
 function make_replay_point(i::InjectorConfig, st::StackTraces.StackTrace)::ReplayPoint
   this_file = frame_file(drop_ft_frames(st)[1])
   short_frames = map((f -> "$(frame_library(f)):$(frame_file(f)):$(frame_line(f))"), drop_ft_frames(st))
@@ -59,7 +61,7 @@ function write_replay_point(i::InjectorConfig, rp::ReplayPoint)
 end
 
 function handle_replay(i::InjectorConfig)::Bool
-  script = i.replay_script
+  script = i.replay_script.script
   head = i.replay_head
   place = i.place_counter
 

--- a/src/Injector.jl
+++ b/src/Injector.jl
@@ -28,7 +28,7 @@ function should_inject(i::InjectorConfig)::Bool
     return handle_replay(i)
   end
 
-  if i.active && i.ninject > 0 && rand(1:i.odds) == 1
+  if i.active && i.n_inject > 0 && rand(1:i.odds) == 1
     st = stacktrace()
     if i.record !== ""
       # We're recording this
@@ -87,7 +87,7 @@ function handle_replay(i::InjectorConfig)::Bool
 end
 
 @inline function decrement_injections(i::InjectorConfig)
-  i.ninject = i.ninject - 1
+  i.n_inject = i.n_inject - 1
 end
 
 @inline function drop_ft_frames(frames)

--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -19,7 +19,7 @@ end
 
 function write_out_logs()
   write_log_to_file()
-  if ft_config.log.outputCSTG
+  if ft_config.log.cstg
     write_logs_for_cstg()
   end
 end
@@ -64,7 +64,7 @@ function format_cstg_stackframe(sf::StackTraces.StackFrame, frame_args::Vector{}
     ""
   end
 
-  println("linfo: $linfo; args: $args")
+  # println("linfo: $linfo; args: $args")
 
   linenum = if ft_config.log.cstgLineNum
     ":$(sf.line)"

--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -37,7 +37,7 @@ Flush output logs.
 """
 function write_log_to_file()
   if length(logger.events) > 0
-    open("$(ft_config.log.filename)_error_log.txt", "a") do file
+    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_error_log.txt", "a") do file
       for e in logger.events
         write(file, "$(to_string(e))\n\n")
       end
@@ -98,22 +98,22 @@ function write_logs_for_cstg()
   props = filter(e -> e.evt_type == :prop, logger.events)
   kills = filter(e -> e.evt_type == :kill, logger.events)
   if length(injects) > 0
-    open("$(ft_config.log.filename)_cstg_injects.txt", "a") do file
+    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_injects.txt", "a") do file
       write_events(file, injects)
     end
   end
   if length(gens) > 0
-    open("$(ft_config.log.filename)_cstg_gens.txt", "a") do file
+    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_gens.txt", "a") do file
       write_events(file, gens)
     end
   end
   if length(props) > 0
-    open("$(ft_config.log.filename)_cstg_props.txt", "a") do file
+    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_props.txt", "a") do file
       write_events(file, props)
     end
   end
   if length(kills) > 0
-    open("$(ft_config.log.filename)_cstg_kills.txt", "a") do file
+    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_kills.txt", "a") do file
       write_events(file, kills)
     end
   end

--- a/src/SharedStructs.jl
+++ b/src/SharedStructs.jl
@@ -1,0 +1,27 @@
+"""
+Struct to describe a function location; used by the Injector
+
+The `avoid` field defaults to `false`—setting this to `true` will make it so
+that if that function will *not* be considered a candidate for injection.
+"""
+struct FunctionRef
+  name::Symbol
+  file::Symbol
+  avoid::Bool
+end
+
+# Convenience functions to make constructing these a little simpler
+FunctionRef(name, file) = FunctionRef(name, file, false)
+FunctionRef(name :: String, file, avoid) = FunctionRef(Symbol(name), file, avoid)
+FunctionRef(name :: Symbol, file :: String, avoid) = FunctionRef(name, Symbol(file), avoid)
+
+"""
+    ReplayPoint(counter, check, module_list)
+
+Represents a point where a `NaN` was injected during program execution.
+"""
+struct ReplayPoint
+  counter::Int64
+  check::Symbol
+  stack::Vector{String}
+end

--- a/src/SharedStructs.jl
+++ b/src/SharedStructs.jl
@@ -25,3 +25,23 @@ struct ReplayPoint
   check::Symbol
   stack::Vector{String}
 end
+
+"""
+    Event
+
+Struct representing some event in the life of a NaN.
+
+`evt_type` options:
+
+ - `:injected`
+ - `:gen`
+ - `:prop`
+ - `:kill`
+"""
+struct Event
+  evt_type::Symbol
+  op::String
+  args::Array{Any}
+  result::Any
+  trace::StackTraces.StackTrace
+end

--- a/src/TrackedFloat.jl
+++ b/src/TrackedFloat.jl
@@ -1,32 +1,5 @@
 abstract type AbstractTrackedFloat <: AbstractFloat end
 
-# This variable is visible module-wide
-injector = make_injector(should_inject=false, odds=0, n_inject=0)
-
-# Old, dumpy API
-function set_inject_nan(i::Injector)
-  injector.active = i.active
-  injector.odds = i.odds
-  injector.ninject = i.ninject
-  injector.functions = i.functions
-  injector.libraries = i.libraries
-  injector.replay = i.replay
-  injector.record = i.record
-  injector.place_counter = i.place_counter
-  injector.replay_script = i.replay_script
-  injector.replay_head = i.replay_head
-end
-
-function set_inject_nan(should_inject::Bool, odds::Int = 10, n_inject = 1, functions = [], libraries = []; replay = "", record = "")
-  injector.active = should_inject
-  injector.odds = odds
-  injector.ninject = n_inject
-  injector.functions = functions
-  injector.libraries = libraries
-  injector.replay = replay
-  injector.record = record
-end
-
 @inline function check_error(fn, injected::Bool, result, args...)
   if any(v -> isfloaterror(v), [args..., result])
     # args is a tuple; we call `collect` to get a Vector without promoting the types
@@ -36,8 +9,8 @@ end
 end
 
 @inline function run_or_inject(fn, args...)
-  if should_inject(injector)
-    decrement_injections(injector)
+  if should_inject(ft_config.inj)
+    decrement_injections(ft_config.inj)
     (NaN, true)
   else
     (fn(args...), false)

--- a/test/config_api_tests.jl
+++ b/test/config_api_tests.jl
@@ -3,6 +3,8 @@ using Test
 include("../src/FloatTracker.jl")
 using .FloatTracker
 
+ft_init()
+
 @testset "set_*_config! tests don't override" begin
   global_config = ft__get_global_ft_config_for_test()
   mirror = FtConfig(LoggerConfig(),
@@ -23,15 +25,3 @@ using .FloatTracker
   @test "$global_config" == "$mirror"
   @test global_config.inj.odds == 42
 end
-
-@testset "timestamp gets added correctly to log config" begin
-  global_config = ft__get_global_ft_config_for_test()
-  fln = global_config.log.filename
-
-  @test match(r"\d+-ft_log", fln) !== nothing
-
-  set_logger_config!(filename="foobar")
-  println(global_config.log.filename)
-  @test match(r"\d+-foobar", global_config.log.filename) !== nothing
-end
-

--- a/test/config_api_tests.jl
+++ b/test/config_api_tests.jl
@@ -11,13 +11,13 @@ using .FloatTracker
   mirror.log.filename = global_config.log.filename
   @test "$global_config" == "$mirror"
 
-  set_injector_config!(active=true, odds=42)
+  config_injector!(active=true, odds=42)
   @test "$global_config" != "$mirror"
   mirror.inj.active = true
   mirror.inj.odds = 42
   @test "$global_config" == "$mirror"
 
-  set_injector_config!(active=false)
+  config_injector!(active=false)
   @test "$global_config" != "$mirror"
   mirror.inj.active = false
   @test "$global_config" == "$mirror"

--- a/test/config_api_tests.jl
+++ b/test/config_api_tests.jl
@@ -1,0 +1,37 @@
+using Test
+
+include("../src/FloatTracker.jl")
+using .FloatTracker
+
+@testset "set_*_config! tests don't override" begin
+  global_config = ft__get_global_ft_config_for_test()
+  mirror = FtConfig(LoggerConfig(),
+                           InjectorConfig(),
+                           SessionConfig())
+  mirror.log.filename = global_config.log.filename
+  @test "$global_config" == "$mirror"
+
+  set_injector_config!(active=true, odds=42)
+  @test "$global_config" != "$mirror"
+  mirror.inj.active = true
+  mirror.inj.odds = 42
+  @test "$global_config" == "$mirror"
+
+  set_injector_config!(active=false)
+  @test "$global_config" != "$mirror"
+  mirror.inj.active = false
+  @test "$global_config" == "$mirror"
+  @test global_config.inj.odds == 42
+end
+
+@testset "timestamp gets added correctly to log config" begin
+  global_config = ft__get_global_ft_config_for_test()
+  fln = global_config.log.filename
+
+  @test match(r"\d+-ft_log", fln) !== nothing
+
+  set_logger_config!(filename="foobar")
+  println(global_config.log.filename)
+  @test match(r"\d+-foobar", global_config.log.filename) !== nothing
+end
+

--- a/test/config_api_tests.jl
+++ b/test/config_api_tests.jl
@@ -3,8 +3,6 @@ using Test
 include("../src/FloatTracker.jl")
 using .FloatTracker
 
-ft_init()
-
 @testset "set_*_config! tests don't override" begin
   global_config = ft__get_global_ft_config_for_test()
   mirror = FtConfig(LoggerConfig(),

--- a/test/injector_tests.jl
+++ b/test/injector_tests.jl
@@ -1,23 +1,25 @@
 using Test
 
-println("loading injector")
-include("../src/Injector.jl")
-println("loading injector... done")
+println("Loading FloatTracker…")
+include("../src/FloatTracker.jl")
+using .FloatTracker
+
+println("FloatTracker loaded")
 
 @testset "should_inject basic behavior" begin
-  i1 = make_injector(odds=1, n_inject=2)
+  i1 = InjectorConfig(odds=1, n_inject=2)
   @test should_inject(i1)
 
-  i2 = make_injector(odds=1, n_inject=0)
+  i2 = InjectorConfig(odds=1, n_inject=0)
   @test ! should_inject(i2)
 
-  i3 = make_injector(odds=10^30, n_inject=2) # No way that this should return true twice in that range
+  i3 = InjectorConfig(odds=10^30, n_inject=2) # No way that this should return true twice in that range
   @test !(should_inject(i3) && should_inject(i3))
 end
 
 @testset "should_inject recording basics" begin
   tmp_file = tempname()         # This should automatically get cleaned up
-  i1 = make_injector(odds=10, n_inject=10, record=tmp_file)
+  i1 = InjectorConfig(odds=10, n_inject=10, record=tmp_file)
   l1 = zeros(Bool, 100)
   l2 = zeros(Bool, 100)
   for i in 1:100
@@ -25,7 +27,7 @@ end
   end
 
   # Ok, now check the replay
-  i2 = make_injector(replay=tmp_file)
+  i2 = InjectorConfig(replay=tmp_file)
   for i in 1:100
     l2[i] = should_inject(i2)
   end

--- a/test/injector_tests.jl
+++ b/test/injector_tests.jl
@@ -4,6 +4,8 @@ println("Loading FloatTracker…")
 include("../src/FloatTracker.jl")
 using .FloatTracker
 
+ft_init()
+
 println("FloatTracker loaded")
 
 @testset "should_inject basic behavior" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using Test
 
+println("--- config API tests ---")
+include("config_api_tests.jl")
+
 println("--- injector tests ---")
 include("injector_tests.jl")
 


### PR DESCRIPTION
This will be version `0.1.0`.

This is a massive refactoring of how you set up FloatTracker. Please see the CHANGELOG for more details.

The primary motivation for this big rewrite is to make it easier to add more things to the configs without necessitating massive changes across the project to make it happen. The old way used positional arguments for a lot of the configs; now we use mostly keyword arguments except in a few carefully-chosen location where keyword arguments would be redundant.