### PR TITLE
Major renaming activity, add cap on number of stack frames to print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ That said, this is research software, so expect some instability as we aim first
 Logger config:
 
  - `allErrors` controls whether or not to print to the catch-all `*_error_log.txt` file. (Now `false` by default.)
- - `maxFrames` controls how many stack frames get printed per event.
+ - `maxFrames` controls how many stack frames get printed per event. (`Unbounded` by default.)
 
 ### Replaced functions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ That said, this is research software, so expect some instability as we aim first
 
 ## 0.2.0
 
+### Added
+
+Logger config:
+
+ - `allErrors` controls whether or not to print to the catch-all `*_error_log.txt` file. (Now `false` by default.)
+ - `maxFrames` controls how many stack frames get printed per event.
+
 ### Replaced functions
 
 Rename to remove the `!` from functions:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Keyword arguments for `config_logger`:
 
  - `cstgArgs::Bool` Include arguments to functions in CSTG output.
 
- - `maxLogs::Union{Int,Unbounded}` Maximum number of events to log; defaults to `Unbounded`.
+ - `maxFrames::Union{Int,Unbounded}` Maximum number of frames to print per even in the logs; defaults to `Unbounded`.
+
+ - `maxLogs::Union{Int,Unbounded}` (Unimplemented as of 0.2.0) Maximum number of events to log; defaults to `Unbounded`.
 
  - `exclusions::Array{Symbol}` Events to not log; defaults to `[:prop]`.
 

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -43,6 +43,8 @@ Struct containing all configuration for the logger.
 
  - `maxLogs::Union{Int,Unbounded}` Maximum number of events to log; defaults to `Unbounded`.
 
+ - `maxFrames::Union{Int,Unbounded}` Maximum number of stack frames to print in logging; defaults to `Unbounded`.
+
  - `exclusions::Array{Symbol}` Events to not log; defaults to `[:prop]`.
 """
 mutable struct LoggerConfig
@@ -53,6 +55,7 @@ mutable struct LoggerConfig
   cstgLineNum::Bool
   cstgArgs::Bool
   maxLogs::Union{Int,Unbounded}
+  maxFrames::Union{Int,Unbounded}
   exclusions::Array{Symbol}
 end
 LoggerConfig(filename) =
@@ -63,13 +66,45 @@ LoggerConfig(filename, buff_size, cstg) =
   LoggerConfig(filename=filename, buffersize=buff_size, print=false, cstg=cstg, cstgLineNum=true, cstgArgs=true)
 
 function LoggerConfig(; filename="ft_log", buffersize=1000, print=false, cstg=false, cstgLineNum=true, cstgArgs=true,
-                      max_logs=Unbounded(), exclusions=[:prop])
-  LoggerConfig(filename, buffersize, print, cstg, cstgLineNum, cstgArgs, max_logs, exclusions)
+                      maxLogs=Unbounded(), maxFrames=Unbounded(), exclusions=[:prop])
+  LoggerConfig(filename, buffersize, print, cstg, cstgLineNum, cstgArgs, maxLogs, maxFrames, exclusions)
 end
 
-#
-# Injector config
-#
+function injects_file()
+  if ft_config.ses.testing
+    ft_config.log.filename
+  else
+    "$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_injects.txt"
+  end
+end
+function gens_file()
+  if ft_config.ses.testing
+    ft_config.log.filename
+  else
+    "$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_gens.txt"
+  end
+end
+function props_file()
+  if ft_config.ses.testing
+    ft_config.log.filename
+  else
+    "$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_props.txt"
+  end
+end
+function kills_file()
+  if ft_config.ses.testing
+    ft_config.log.filename
+  else
+    "$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_kills.txt"
+  end
+end
+function errors_file()
+  if ft_config.ses.testing
+    ft_config.log.filename
+  else
+    "$(ft_config.ses.sessionId)-$(ft_config.log.filename)_error_log.txt"
+  end
+end
 
 struct InjectorScript
   script::Array{ReplayPoint}
@@ -151,10 +186,11 @@ mutable struct SessionConfig
   maxKills::Union{Int,Unbounded}
   maxEvents::Union{Int,Unbounded}
   sessionId::String                # Defaults to current timestamp like yyyymmmddHHMMss
+  testing::Bool                    # Don't document this: this is only for running tests
 end
 function SessionConfig()
   now_str = Dates.format(now(), "yyyymmddHHMMSS")
-  SessionConfig(Unbounded(), Unbounded(), Unbounded(), Unbounded(), now_str)
+  SessionConfig(Unbounded(), Unbounded(), Unbounded(), Unbounded(), now_str, false)
 end
 
 """

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -3,7 +3,7 @@ module FloatTracker
 export FtConfig, ft_init, TrackedFloat16, TrackedFloat32, TrackedFloat64, FunctionRef
 export LoggerConfig, config_logger, exclude_stacktrace, print_log, write_out_logs
 export InjectorConfig, config_injector, enable_nan_injection, disable_nan_injection, record_injection, replay_injection
-export SessionConfig
+export SessionConfig, config_session
 
 include("SharedStructs.jl")     # Structures used in multiple places throughout FloatTracker
 include("Config.jl")            # Primary interface routines: routines to control injection, logging, etc.

--- a/src/FloatTracker.jl
+++ b/src/FloatTracker.jl
@@ -12,6 +12,7 @@ include("Logger.jl")            # Formatting and writing of error/event logs
 include("Injector.jl")          # NaN-injection logic
 include("TrackedFloat.jl")      # Principle datatype; overrides of all Base.* functions
 
+# Call ft_init() when module gets loaded up
 __init__() = ft_init()
 
 end

--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -33,11 +33,11 @@ end
 """
     write_log_to_file()
 
-Flush output logs.
+Flush error log.
 """
 function write_log_to_file()
   if length(logger.events) > 0
-    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_error_log.txt", "a") do file
+    open(errors_file(), "a") do file
       for e in logger.events
         write(file, "$(to_string(e))\n\n")
       end
@@ -82,8 +82,8 @@ function write_events(file, events::Vector{Event})
       # correct args in top frame so it's the values not just the traces
       write(file, "$(format_cstg_stackframe(e.trace[1], e.args))\n")
 
-      # write remaining frames
-      for sf in e.trace[2:end]
+      # write remaining frames up to ftv-config.log.maxFrames
+      for sf in e.trace[(isa(ft_config.log.maxFrames, Unbounded) ? (2:end) : (2:(ft_config.log.maxFrames + 1)))]
         write(file, "$(format_cstg_stackframe(sf))\n")
       end
 
@@ -98,22 +98,22 @@ function write_logs_for_cstg()
   props = filter(e -> e.evt_type == :prop, logger.events)
   kills = filter(e -> e.evt_type == :kill, logger.events)
   if length(injects) > 0
-    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_injects.txt", "a") do file
+    open(injects_file(), "a") do file
       write_events(file, injects)
     end
   end
   if length(gens) > 0
-    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_gens.txt", "a") do file
+    open(gens_file(), "a") do file
       write_events(file, gens)
     end
   end
   if length(props) > 0
-    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_props.txt", "a") do file
+    open(props_file(), "a") do file
       write_events(file, props)
     end
   end
   if length(kills) > 0
-    open("$(ft_config.ses.sessionId)-$(ft_config.log.filename)_cstg_kills.txt", "a") do file
+    open(kills_file(), "a") do file
       write_events(file, kills)
     end
   end

--- a/test/config_api_tests.jl
+++ b/test/config_api_tests.jl
@@ -3,7 +3,7 @@ using Test
 include("../src/FloatTracker.jl")
 using .FloatTracker
 
-@testset "set_*_config! tests don't override" begin
+@testset "config_* doesn't override everything" begin
   global_config = ft__get_global_ft_config_for_test()
   mirror = FtConfig(LoggerConfig(),
                            InjectorConfig(),

--- a/test/injector_tests.jl
+++ b/test/injector_tests.jl
@@ -4,8 +4,6 @@ println("Loading FloatTracker…")
 include("../src/FloatTracker.jl")
 using .FloatTracker
 
-ft_init()
-
 println("FloatTracker loaded")
 
 @testset "should_inject basic behavior" begin

--- a/test/injector_tests.jl
+++ b/test/injector_tests.jl
@@ -7,19 +7,19 @@ using .FloatTracker
 println("FloatTracker loaded")
 
 @testset "should_inject basic behavior" begin
-  i1 = InjectorConfig(odds=1, n_inject=2)
+  i1 = InjectorConfig(active=true, odds=1, n_inject=2)
   @test should_inject(i1)
 
-  i2 = InjectorConfig(odds=1, n_inject=0)
+  i2 = InjectorConfig(active=true, odds=1, n_inject=0)
   @test ! should_inject(i2)
 
-  i3 = InjectorConfig(odds=10^30, n_inject=2) # No way that this should return true twice in that range
+  i3 = InjectorConfig(active=true, odds=10^30, n_inject=2) # No way that this should return true twice in that range
   @test !(should_inject(i3) && should_inject(i3))
 end
 
 @testset "should_inject recording basics" begin
   tmp_file = tempname()         # This should automatically get cleaned up
-  i1 = InjectorConfig(odds=10, n_inject=10, record=tmp_file)
+  i1 = InjectorConfig(active=true, odds=10, n_inject=10, record=tmp_file)
   l1 = zeros(Bool, 100)
   l2 = zeros(Bool, 100)
   for i in 1:100

--- a/test/logger_tests.jl
+++ b/test/logger_tests.jl
@@ -1,0 +1,32 @@
+using Test
+
+println("Loading FloatTracker…")
+include("../src/FloatTracker.jl")
+using .FloatTracker
+
+println("FloatTracker loaded")
+
+f5(n) = n-2
+
+f4(n) = f5(n+n)
+
+f3(n) = f4(n-1)
+
+f2(n) = f3(n*2)
+
+f1(n) = f2(n+1)
+
+f0(n) = f1((n * n - 4.0) / (n - 2.0))
+
+@testset "maxFrames: only print out n stack frames" begin
+  tmp_file = tempname()         # This should automatically get cleaned up
+  # WORKING HERE: trying to make it so I can configure the logs to go out to the temp file
+  config_session!(testing=true)
+  config_logger!(filename=tmp_file, maxFrames=3, printToStdOut=true)
+
+  floaty = TrackedFloat32(2.0)
+  f0(floaty)
+  write_out_logs()
+  println("file: $tmp_file")
+  run(`cat $tmp_file`)
+end

--- a/test/logger_tests.jl
+++ b/test/logger_tests.jl
@@ -19,14 +19,27 @@ f1(n) = f2(n+1)
 f0(n) = f1((n * n - 4.0) / (n - 2.0))
 
 @testset "maxFrames: only print out n stack frames" begin
-  tmp_file = tempname()         # This should automatically get cleaned up
-  # WORKING HERE: trying to make it so I can configure the logs to go out to the temp file
-  config_session!(testing=true)
-  config_logger!(filename=tmp_file, maxFrames=3, printToStdOut=true)
+  ft_init()
+  config_session(testing=true)
+  tmp1 = tempname()         # This should automatically get cleaned up
+  tmp2 = tempname()
 
   floaty = TrackedFloat32(2.0)
+
+  exclude_stacktrace([:kill,:inject])
+
+  config_logger(filename=tmp1, buffersize=1)
   f0(floaty)
   write_out_logs()
-  println("file: $tmp_file")
-  run(`cat $tmp_file`)
+
+  # We get 6 log events, and with this config there should be 6 lines + space
+  # for every event
+  @test countlines(tmp1) > 7 * 6
+
+  config_logger(filename=tmp2, maxFrames=3)
+  f0(floaty)
+  write_out_logs()
+
+  # We get the ((check_error line) + (3 lines of context) + (blank line) = 5) * (6 events)
+  @test countlines(tmp2) == 5 * 6
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,5 +6,8 @@ include("config_api_tests.jl")
 println("--- injector tests ---")
 include("injector_tests.jl")
 
+println("--- logger tests ---")
+include("logger_tests.jl")
+
 println("--- recording session tests ---")
 include("recording_session_tests.jl")


### PR DESCRIPTION
This should be released as version `0.2.0`.

Issues closed:
 - #25 Truncate stack traces