### PR TITLE
Add event limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ We strive to follow [SemVer](https://semver.org/) conventions. Per [item 4 in th
 
 That said, this is research software, so expect some instability as we aim first and foremost to push the boundaries of what is possible.
 
+## 0.3.0
+
+### Added
+
+Event limit in logger works: set `maxLogs` to control how many events get logged. FloatTracker stops collecting stack traces after this, so should run much faster once the threshold has been hit. Defaults to `Unbounded()`.
+
 ## 0.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Keyword arguments for `config_logger`:
 
  - `maxFrames::Union{Int,Unbounded}` Maximum number of frames to print per even in the logs; defaults to `Unbounded`.
 
- - `maxLogs::Union{Int,Unbounded}` (Unimplemented as of 0.2.0) Maximum number of events to log; defaults to `Unbounded`.
+ - `maxLogs::Union{Int,Unbounded}` Maximum number of events to log; defaults to `Unbounded`.
 
  - `exclusions::Array{Symbol}` Events to not log; defaults to `[:prop]`.
 

--- a/src/TrackedFloat.jl
+++ b/src/TrackedFloat.jl
@@ -6,7 +6,7 @@ abstract type AbstractTrackedFloat <: AbstractFloat end
     if isa(ft_config.log.maxLogs, Int) && ft_config.log.maxLogs > 0
       ft_config.log.maxLogs -= 1
       log_event(event(string(fn), collect(args), result, injected))
-    else if isa(ft_config.log.maxLogs, Unbounded)
+    elseif isa(ft_config.log.maxLogs, Unbounded)
       log_event(event(string(fn), collect(args), result, injected))
     end
   end

--- a/src/TrackedFloat.jl
+++ b/src/TrackedFloat.jl
@@ -3,8 +3,12 @@ abstract type AbstractTrackedFloat <: AbstractFloat end
 @inline function check_error(fn, injected::Bool, result, args...)
   if any(v -> isfloaterror(v), [args..., result])
     # args is a tuple; we call `collect` to get a Vector without promoting the types
-    e = event(string(fn), collect(args), result, injected)
-    log_event(e)
+    if isa(ft_config.log.maxLogs, Int) && ft_config.log.maxLogs > 0
+      ft_config.log.maxLogs -= 1
+      log_event(event(string(fn), collect(args), result, injected))
+    else if isa(ft_config.log.maxLogs, Unbounded)
+      log_event(event(string(fn), collect(args), result, injected))
+    end
   end
 end
 

--- a/test/logger_tests.jl
+++ b/test/logger_tests.jl
@@ -43,3 +43,28 @@ f0(n) = f1((n * n - 4.0) / (n - 2.0))
   # We get the ((check_error line) + (3 lines of context) + (blank line) = 5) * (6 events)
   @test countlines(tmp2) == 5 * 6
 end
+
+@testset "maxLogs: only log n events then stop" begin
+  ft_init()
+  config_session(testing=true)
+  tmp1 = tempname()         # This should automatically get cleaned up
+  tmp2 = tempname()
+
+  floaty = TrackedFloat32(2.0)
+
+  exclude_stacktrace([:kill,:inject])
+
+  config_logger(filename=tmp1, maxFrames=1, buffersize=1)
+  f0(floaty)
+  write_out_logs()
+
+  # We get the ((check_error line) + (1 lines of context) + (blank line) = 3) * (6 events)
+  @test countlines(tmp1) == 18
+
+  config_logger(filename=tmp2, maxLogs=3)
+  f0(floaty)
+  write_out_logs()
+
+  # We get the ((check_error line) + (1 lines of context) + (blank line) = 3) * (3 events)
+  @test countlines(tmp2) == 9
+end


### PR DESCRIPTION
Closes #24

Adds the `maxLogs` feature which limits how many events get logged.